### PR TITLE
Fixed an issue where locations would not be considered within a plot

### DIFF
--- a/src/main/java/com/atherys/towns/service/PlotService.java
+++ b/src/main/java/com/atherys/towns/service/PlotService.java
@@ -87,7 +87,7 @@ public class PlotService {
     }
 
     public boolean isLocationWithinPlot(Location<World> location, Plot plot) {
-        return MathUtils.vectorXZFitsInRange(location.getPosition(), plot.getSouthWestCorner(), plot.getNorthEastCorner());
+        return MathUtils.vectorXZFitsInRange(location.getBlockPosition(), plot.getSouthWestCorner(), plot.getNorthEastCorner());
     }
 
     public boolean plotIntersectsAnyOthers(Plot plot) {


### PR DESCRIPTION
A player's location is always in decimal, whereas plots are always an integer. This causes issues when checking negative coordinates as the origin of the block is in the north-west corner of the block.

If I have a plot A(-10, -10) B(-20,-20), a player at -9.5, -10 would be standing on the block at -10, -10 but would not be considered in the plot.
