### PR TITLE
Remove equals/hashCode methods from JPA entities

### DIFF
--- a/src/main/java/com/atherys/towns/model/entity/Plot.java
+++ b/src/main/java/com/atherys/towns/model/entity/Plot.java
@@ -87,22 +87,6 @@ public class Plot implements Identifiable<Long> {
         this.owner = owner;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Plot plot = (Plot) o;
-        return id.equals(plot.id) &&
-                town.equals(plot.town) &&
-                swCorner.equals(plot.swCorner) &&
-                neCorner.equals(plot.neCorner);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, swCorner, neCorner);
-    }
-
     protected int getVersion() {
         return version;
     }

--- a/src/main/java/com/atherys/towns/model/entity/Resident.java
+++ b/src/main/java/com/atherys/towns/model/entity/Resident.java
@@ -149,18 +149,4 @@ public class Resident implements SpongeIdentifiable, Identifiable<UUID> {
         this.version = version;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Resident resident = (Resident) o;
-        return id.equals(resident.id) &&
-                name.equals(resident.name) &&
-                town.equals(resident.town);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, name);
-    }
 }

--- a/src/main/java/com/atherys/towns/model/entity/Town.java
+++ b/src/main/java/com/atherys/towns/model/entity/Town.java
@@ -222,31 +222,4 @@ public class Town implements Identifiable<Long> {
         this.bank = bank;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        Town town = (Town) o;
-        return maxSize == town.maxSize &&
-                freelyJoinable == town.freelyJoinable &&
-                pvpEnabled == town.pvpEnabled &&
-                version == town.version &&
-                Objects.equals(id, town.id) &&
-                Objects.equals(name, town.name) &&
-                Objects.equals(description, town.description) &&
-                Objects.equals(motd, town.motd) &&
-                Objects.equals(color, town.color) &&
-                Objects.equals(leader, town.leader) &&
-                Objects.equals(nation, town.nation) &&
-                Objects.equals(world, town.world) &&
-                Objects.equals(spawn, town.spawn) &&
-                Objects.equals(residents, town.residents) &&
-                Objects.equals(plots, town.plots) &&
-                Objects.equals(bank, town.bank);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, name, description, motd, color, leader, nation, world, spawn, residents, plots, maxSize, freelyJoinable, pvpEnabled, bank, version);
-    }
 }


### PR DESCRIPTION
These methods are only currently causing us grief, the way our caching is written means that there will only ever be one java instance per record in the database. 

As only one entity instance exists, we can use the Object's implementation of equals/hashcode.
