### PR TITLE
Changed chat prefix to match format suggested by Sanders

### DIFF
--- a/src/main/java/com/atherys/towns/TownsConfig.java
+++ b/src/main/java/com/atherys/towns/TownsConfig.java
@@ -25,6 +25,12 @@ public class TownsConfig extends PluginConfig {
     @Setting("min-residents-to-create-town")
     public int MIN_RESIDENTS_TOWN_CREATE = 3;
 
+    @Setting("nation-chat-prefix")
+    public String NATION_CHAT_PREFIX = "&f[&eN&f]&r";
+
+    @Setting("town-chat-prefix")
+    public String TOWN_CHAT_PREFIX = "&f[&bT&f]&r";
+
     @Setting("respawn-in-town")
     public boolean SPAWN_IN_TOWN = true;
 

--- a/src/main/java/com/atherys/towns/chat/NationChannel.java
+++ b/src/main/java/com/atherys/towns/chat/NationChannel.java
@@ -17,7 +17,7 @@ public class NationChannel extends AtherysChannel {
         aliases.add("nc");
         this.setAliases(aliases);
         this.setPermission(PERMISSION);
-        this.setPrefix("&6[&eNation&6]&r");
+        this.setPrefix("&f[&eN&f]&r");
         this.setSuffix("");
         this.setFormat("%cprefix %player: %message %csuffix");
         this.setName("&bNation");

--- a/src/main/java/com/atherys/towns/chat/NationChannel.java
+++ b/src/main/java/com/atherys/towns/chat/NationChannel.java
@@ -17,7 +17,7 @@ public class NationChannel extends AtherysChannel {
         aliases.add("nc");
         this.setAliases(aliases);
         this.setPermission(PERMISSION);
-        this.setPrefix("&f[&eN&f]&r");
+        this.setPrefix(AtherysTowns.getInstance().getConfig().NATION_CHAT_PREFIX);
         this.setSuffix("");
         this.setFormat("%cprefix %player: %message %csuffix");
         this.setName("&bNation");

--- a/src/main/java/com/atherys/towns/chat/TownChannel.java
+++ b/src/main/java/com/atherys/towns/chat/TownChannel.java
@@ -17,7 +17,7 @@ public class TownChannel extends AtherysChannel {
         aliases.add("tc");
         this.setAliases(aliases);
         this.setPermission(PERMISSION);
-        this.setPrefix("&f[&bT&f]&r");
+        this.setPrefix(AtherysTowns.getInstance().getConfig().TOWN_CHAT_PREFIX);
         this.setSuffix("");
         this.setFormat("%cprefix %player: %message %csuffix");
         this.setName("&bTown");

--- a/src/main/java/com/atherys/towns/chat/TownChannel.java
+++ b/src/main/java/com/atherys/towns/chat/TownChannel.java
@@ -17,7 +17,7 @@ public class TownChannel extends AtherysChannel {
         aliases.add("tc");
         this.setAliases(aliases);
         this.setPermission(PERMISSION);
-        this.setPrefix("&2[&bTown&2]&r");
+        this.setPrefix("&f[&bT&f]&r");
         this.setSuffix("");
         this.setFormat("%cprefix %player: %message %csuffix");
         this.setName("&bTown");


### PR DESCRIPTION
Changed chat prefix to align with format from sanders:
Nation Chat- &f[&eN&f]&f[&6Gennaian Isles&f] &fSanders&e:I want global turned off!
Town Chat- &f[&bT&f]&f[&6Gennaian Isles&f] &fSanders&b:I want global turned off!