### PR TITLE
Town Raiding Implementation

### DIFF
--- a/src/main/java/com/atherys/towns/AtherysTowns.java
+++ b/src/main/java/com/atherys/towns/AtherysTowns.java
@@ -19,6 +19,7 @@ import com.atherys.towns.command.town.TownCommand;
 import com.atherys.towns.facade.*;
 import com.atherys.towns.listener.PlayerListener;
 import com.atherys.towns.listener.ProtectionListener;
+import com.atherys.towns.listener.RaidListener;
 import com.atherys.towns.model.entity.Nation;
 import com.atherys.towns.model.entity.Plot;
 import com.atherys.towns.model.entity.Resident;
@@ -103,6 +104,7 @@ public class AtherysTowns {
 
         Sponge.getEventManager().registerListeners(this, components.playerListener);
         Sponge.getEventManager().registerListeners(this, components.protectionListener);
+        Sponge.getEventManager().registerListeners(this, components.raidListener);
         AtherysChat.getInstance().getChatService().registerChannel(new TownChannel());
         AtherysChat.getInstance().getChatService().registerChannel(new NationChannel());
 
@@ -220,6 +222,10 @@ public class AtherysTowns {
         return components.townsMessagingFacade;
     }
 
+    public TownRaidService getTownRaidService() {
+        return components.townRaidService;
+    }
+
     public NationFacade getNationFacade() {
         return components.nationFacade;
     }
@@ -311,6 +317,9 @@ public class AtherysTowns {
         private TownsPermissionService townsPermissionService;
 
         @Inject
+        private TownRaidService townRaidService;
+
+        @Inject
         private TownsMessagingFacade townsMessagingFacade;
 
         @Inject
@@ -351,5 +360,8 @@ public class AtherysTowns {
 
         @Inject
         private ProtectionListener protectionListener;
+
+        @Inject
+        private RaidListener raidListener;
     }
 }

--- a/src/main/java/com/atherys/towns/AtherysTowns.java
+++ b/src/main/java/com/atherys/towns/AtherysTowns.java
@@ -100,6 +100,7 @@ public class AtherysTowns {
     private void start() {
         getRoleService().init();
         getTownsCache().initCache();
+        getTownRaidService().initRaidTimer();
         getPlotBorderFacade().initBorderTask();
 
         Sponge.getEventManager().registerListeners(this, components.playerListener);

--- a/src/main/java/com/atherys/towns/AtherysTowns.java
+++ b/src/main/java/com/atherys/towns/AtherysTowns.java
@@ -260,6 +260,10 @@ public class AtherysTowns {
         return components.plotBorderFacade;
     }
 
+    public TownRaidFacade getTownRaidFacade() {
+        return components.townRaidFacade;
+    }
+
     public TownsCache getTownsCache() {
         return components.townsCache;
     }
@@ -338,6 +342,9 @@ public class AtherysTowns {
 
         @Inject
         private PlotBorderFacade plotBorderFacade;
+
+        @Inject
+        private TownRaidFacade townRaidFacade;
 
         @Inject
         private PlayerListener playerListener;

--- a/src/main/java/com/atherys/towns/AtherysTownsModule.java
+++ b/src/main/java/com/atherys/towns/AtherysTownsModule.java
@@ -50,6 +50,7 @@ public class AtherysTownsModule extends AbstractModule {
         bind(PlotSelectionFacade.class);
         bind(TownsMessagingFacade.class);
         bind(TownAdminFacade.class);
+        bind(TownRaidFacade.class);
         bind(PollFacade.class);
         bind(PlotBorderFacade.class);
     }

--- a/src/main/java/com/atherys/towns/AtherysTownsModule.java
+++ b/src/main/java/com/atherys/towns/AtherysTownsModule.java
@@ -39,6 +39,7 @@ public class AtherysTownsModule extends AbstractModule {
         bind(PlotService.class);
         bind(ResidentService.class);
         bind(PollService.class);
+        bind(TownRaidService.class);
         bind(TownsPermissionService.class);
 
         // Facades

--- a/src/main/java/com/atherys/towns/TownsConfig.java
+++ b/src/main/java/com/atherys/towns/TownsConfig.java
@@ -2,6 +2,7 @@ package com.atherys.towns;
 
 import com.atherys.core.utils.PluginConfig;
 import com.atherys.towns.config.NationConfig;
+import com.atherys.towns.config.RaidConfig;
 import com.atherys.towns.config.TownConfig;
 import com.google.inject.Singleton;
 import ninja.leaping.configurate.objectmapping.Setting;
@@ -33,6 +34,9 @@ public class TownsConfig extends PluginConfig {
 
     @Setting("town")
     public TownConfig TOWN = new TownConfig();
+
+    @Setting("raid")
+    public RaidConfig RAID = new RaidConfig();
 
     protected TownsConfig() throws IOException {
         super("config/" + AtherysTowns.ID, "config.conf");

--- a/src/main/java/com/atherys/towns/TownsConfig.java
+++ b/src/main/java/com/atherys/towns/TownsConfig.java
@@ -29,14 +29,14 @@ public class TownsConfig extends PluginConfig {
     @Setting("respawn-in-town")
     public boolean SPAWN_IN_TOWN = true;
 
+    @Setting("raid")
+    public RaidConfig RAID = new RaidConfig();
+
     @Setting("nation")
     public NationConfig NATION = new NationConfig();
 
     @Setting("town")
     public TownConfig TOWN = new TownConfig();
-
-    @Setting("raid")
-    public RaidConfig RAID = new RaidConfig();
 
     protected TownsConfig() throws IOException {
         super("config/" + AtherysTowns.ID, "config.conf");

--- a/src/main/java/com/atherys/towns/api/permission/PermissionRegistryModule.java
+++ b/src/main/java/com/atherys/towns/api/permission/PermissionRegistryModule.java
@@ -37,6 +37,8 @@ public class PermissionRegistryModule implements CatalogRegistryModule<Permissio
                 TownPermissions.SET_PERMISSION,
                 TownPermissions.SET_ROLE,
                 TownPermissions.RUIN_TOWN,
+                TownPermissions.START_RAID,
+                TownPermissions.CANCEL_RAID,
                 TownPermissions.WITHDRAW_FROM_BANK,
                 TownPermissions.DEPOSIT_INTO_BANK,
                 TownPermissions.JOIN_NATION,

--- a/src/main/java/com/atherys/towns/api/permission/town/TownPermissions.java
+++ b/src/main/java/com/atherys/towns/api/permission/town/TownPermissions.java
@@ -63,4 +63,10 @@ public final class TownPermissions {
 
     // permission to destroy the town
     public static final TownPermission RUIN_TOWN = new TownPermission("atherystowns.town.ruin", "Ruin Town");
+
+    // permission to start a raid on an enemy town
+    public static final TownPermission START_RAID = new TownPermission("atherystowns.town.raid.start", "Start Raid");
+
+    // permission to cancel a raid on an enemy town
+    public static final TownPermission CANCEL_RAID = new TownPermission("atherystowns.town.raid.cancel", "Cancel Raid");
 }

--- a/src/main/java/com/atherys/towns/command/town/TownCommand.java
+++ b/src/main/java/com/atherys/towns/command/town/TownCommand.java
@@ -39,7 +39,8 @@ import javax.annotation.Nonnull;
         DepositTownCommand.class,
         SetTownSpawnCommand.class,
         TownSpawnCommand.class,
-        TownRoleCommand.class
+        TownRoleCommand.class,
+        TownRaidCommand.class
 })
 @Permission("atherystowns.town.base")
 @HelpCommand(

--- a/src/main/java/com/atherys/towns/command/town/TownRaidCancelCommand.java
+++ b/src/main/java/com/atherys/towns/command/town/TownRaidCancelCommand.java
@@ -1,36 +1,27 @@
 package com.atherys.towns.command.town;
 
-import com.atherys.core.command.ParameterizedCommand;
 import com.atherys.core.command.PlayerCommand;
 import com.atherys.core.command.annotation.Aliases;
 import com.atherys.core.command.annotation.Description;
 import com.atherys.core.command.annotation.Permission;
 import com.atherys.towns.AtherysTowns;
-import com.atherys.towns.model.entity.Town;
-import com.atherys.towns.util.TownsElements;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
-import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.entity.living.player.Player;
 
 import javax.annotation.Nonnull;
 
-@Aliases("Create")
-@Description("Creates a town raid point at the current player location.")
-@Permission("atherystowns.town.raid")
-public class TownRaidCreateCommand implements PlayerCommand, ParameterizedCommand {
-    @Override
-    public CommandElement[] getArguments() {
-        return new CommandElement[]{
-                TownsElements.town()
-        };
-    }
+@Aliases("Cancel")
+@Description("Cancels your active town raid spawn point.")
+@Permission("atherystowns.town.raid.cancel")
+public class TownRaidCancelCommand implements PlayerCommand {
 
     @Nonnull
     @Override
     public CommandResult execute(@Nonnull Player source, @Nonnull CommandContext args) throws CommandException {
-        AtherysTowns.getInstance().getTownRaidFacade().createRaidPoint(source, args.<Town>getOne("town").get());
+        AtherysTowns.getInstance().getTownRaidFacade().removeRaidPoint(source);
         return CommandResult.success();
     }
+
 }

--- a/src/main/java/com/atherys/towns/command/town/TownRaidCommand.java
+++ b/src/main/java/com/atherys/towns/command/town/TownRaidCommand.java
@@ -1,0 +1,25 @@
+package com.atherys.towns.command.town;
+
+import com.atherys.core.command.annotation.Aliases;
+import com.atherys.core.command.annotation.Children;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.spec.CommandExecutor;
+
+import javax.annotation.Nonnull;
+
+@Aliases("raid")
+@Children({
+        TownRaidCreateCommand.class,
+        TownRaidInfoCommand.class
+})
+public class TownRaidCommand implements CommandExecutor {
+
+    @Nonnull
+    @Override
+    public CommandResult execute(@Nonnull CommandSource src, @Nonnull CommandContext args) throws CommandException {
+        return CommandResult.empty();
+    }
+}

--- a/src/main/java/com/atherys/towns/command/town/TownRaidCommand.java
+++ b/src/main/java/com/atherys/towns/command/town/TownRaidCommand.java
@@ -1,25 +1,28 @@
 package com.atherys.towns.command.town;
 
+import com.atherys.core.command.PlayerCommand;
 import com.atherys.core.command.annotation.Aliases;
 import com.atherys.core.command.annotation.Children;
+import com.atherys.towns.AtherysTowns;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;
-import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
-import org.spongepowered.api.command.spec.CommandExecutor;
+import org.spongepowered.api.entity.living.player.Player;
 
 import javax.annotation.Nonnull;
 
 @Aliases("raid")
 @Children({
-        TownRaidCreateCommand.class,
-        TownRaidInfoCommand.class
+        TownRaidStartCommand.class,
+        TownRaidInfoCommand.class,
+        TownRaidCancelCommand.class
 })
-public class TownRaidCommand implements CommandExecutor {
+public class TownRaidCommand implements PlayerCommand {
 
     @Nonnull
     @Override
-    public CommandResult execute(@Nonnull CommandSource src, @Nonnull CommandContext args) throws CommandException {
+    public CommandResult execute(@Nonnull Player source, @Nonnull CommandContext args) throws CommandException {
+        AtherysTowns.getInstance().getTownRaidFacade().sendRaidPointInfo(source);
         return CommandResult.empty();
     }
 }

--- a/src/main/java/com/atherys/towns/command/town/TownRaidCreateCommand.java
+++ b/src/main/java/com/atherys/towns/command/town/TownRaidCreateCommand.java
@@ -1,0 +1,25 @@
+package com.atherys.towns.command.town;
+
+import com.atherys.core.command.PlayerCommand;
+import com.atherys.core.command.annotation.Aliases;
+import com.atherys.core.command.annotation.Description;
+import com.atherys.towns.AtherysTowns;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.entity.living.player.Player;
+
+import javax.annotation.Nonnull;
+
+@Aliases("Create")
+@Description("Creates a town raid point at the current player location.")
+public class TownRaidCreateCommand implements PlayerCommand {
+
+    @Nonnull
+    @Override
+    public CommandResult execute(@Nonnull Player source, @Nonnull CommandContext args) throws CommandException {
+        AtherysTowns.getInstance().getTownRaidFacade().createRaidPoint(source);
+        return CommandResult.success();
+    }
+
+}

--- a/src/main/java/com/atherys/towns/command/town/TownRaidCreateCommand.java
+++ b/src/main/java/com/atherys/towns/command/town/TownRaidCreateCommand.java
@@ -1,25 +1,36 @@
 package com.atherys.towns.command.town;
 
+import com.atherys.core.command.ParameterizedCommand;
 import com.atherys.core.command.PlayerCommand;
 import com.atherys.core.command.annotation.Aliases;
 import com.atherys.core.command.annotation.Description;
+import com.atherys.core.command.annotation.Permission;
 import com.atherys.towns.AtherysTowns;
+import com.atherys.towns.model.entity.Town;
+import com.atherys.towns.util.TownsElements;
 import org.spongepowered.api.command.CommandException;
 import org.spongepowered.api.command.CommandResult;
 import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
 import org.spongepowered.api.entity.living.player.Player;
 
 import javax.annotation.Nonnull;
 
 @Aliases("Create")
 @Description("Creates a town raid point at the current player location.")
-public class TownRaidCreateCommand implements PlayerCommand {
+@Permission("atherystowns.town.raid")
+public class TownRaidCreateCommand implements PlayerCommand, ParameterizedCommand {
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[]{
+                TownsElements.town()
+        };
+    }
 
     @Nonnull
     @Override
     public CommandResult execute(@Nonnull Player source, @Nonnull CommandContext args) throws CommandException {
-        AtherysTowns.getInstance().getTownRaidFacade().createRaidPoint(source);
+        AtherysTowns.getInstance().getTownRaidFacade().createRaidPoint(source, args.<Town>getOne("town").get());
         return CommandResult.success();
     }
-
 }

--- a/src/main/java/com/atherys/towns/command/town/TownRaidInfoCommand.java
+++ b/src/main/java/com/atherys/towns/command/town/TownRaidInfoCommand.java
@@ -1,0 +1,25 @@
+package com.atherys.towns.command.town;
+
+import com.atherys.core.command.PlayerCommand;
+import com.atherys.core.command.annotation.Aliases;
+import com.atherys.core.command.annotation.Description;
+import com.atherys.towns.AtherysTowns;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.entity.living.player.Player;
+
+import javax.annotation.Nonnull;
+
+@Aliases("Info")
+@Description("Shows current raid point information.")
+public class TownRaidInfoCommand implements PlayerCommand {
+
+    @Nonnull
+    @Override
+    public CommandResult execute(@Nonnull Player source, @Nonnull CommandContext args) throws CommandException {
+        AtherysTowns.getInstance().getTownRaidFacade().sendRaidPointInfo(source);
+        return CommandResult.success();
+    }
+
+}

--- a/src/main/java/com/atherys/towns/command/town/TownRaidStartCommand.java
+++ b/src/main/java/com/atherys/towns/command/town/TownRaidStartCommand.java
@@ -1,0 +1,36 @@
+package com.atherys.towns.command.town;
+
+import com.atherys.core.command.ParameterizedCommand;
+import com.atherys.core.command.PlayerCommand;
+import com.atherys.core.command.annotation.Aliases;
+import com.atherys.core.command.annotation.Description;
+import com.atherys.core.command.annotation.Permission;
+import com.atherys.towns.AtherysTowns;
+import com.atherys.towns.model.entity.Town;
+import com.atherys.towns.util.TownsElements;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.args.CommandElement;
+import org.spongepowered.api.entity.living.player.Player;
+
+import javax.annotation.Nonnull;
+
+@Aliases("Create")
+@Description("Creates a town raid point at the current player location.")
+@Permission("atherystowns.town.raid.create")
+public class TownRaidStartCommand implements PlayerCommand, ParameterizedCommand {
+    @Override
+    public CommandElement[] getArguments() {
+        return new CommandElement[]{
+                TownsElements.town()
+        };
+    }
+
+    @Nonnull
+    @Override
+    public CommandResult execute(@Nonnull Player source, @Nonnull CommandContext args) throws CommandException {
+        AtherysTowns.getInstance().getTownRaidFacade().createRaidPoint(source, args.<Town>getOne("town").get());
+        return CommandResult.success();
+    }
+}

--- a/src/main/java/com/atherys/towns/command/town/TownRaidStartCommand.java
+++ b/src/main/java/com/atherys/towns/command/town/TownRaidStartCommand.java
@@ -18,7 +18,7 @@ import javax.annotation.Nonnull;
 
 @Aliases("Create")
 @Description("Creates a town raid point at the current player location.")
-@Permission("atherystowns.town.raid.create")
+@Permission("atherystowns.town.raid.start")
 public class TownRaidStartCommand implements PlayerCommand, ParameterizedCommand {
     @Override
     public CommandElement[] getArguments() {

--- a/src/main/java/com/atherys/towns/config/RaidConfig.java
+++ b/src/main/java/com/atherys/towns/config/RaidConfig.java
@@ -4,18 +4,19 @@ import ninja.leaping.configurate.objectmapping.Setting;
 import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 @ConfigSerializable
 public class RaidConfig {
 
     @Setting("town-raid-health")
-    public int RAID_HEALTH = 1024;
+    public double RAID_HEALTH = 1024.00;
 
     @Setting("town-raid-duration")
-    public Duration RAID_DURATION;
+    public Duration RAID_DURATION = Duration.of(1, ChronoUnit.MINUTES);
 
     @Setting("town-raid-cooldown")
-    public Duration RAID_COOLDOWN;
+    public Duration RAID_COOLDOWN = Duration.of(1, ChronoUnit.MINUTES);
 
     @Setting("town-raid-cost")
     public double RAID_COST;
@@ -25,5 +26,8 @@ public class RaidConfig {
 
     @Setting("town-raid-creation-distance")
     public int RAID_CREATION_DISTANCE;
+
+    @Setting("town-raid-damage-per-spawn")
+    public int RAID_DAMAGE_PER_SPAWN = 50;
 
 }

--- a/src/main/java/com/atherys/towns/config/RaidConfig.java
+++ b/src/main/java/com/atherys/towns/config/RaidConfig.java
@@ -25,7 +25,7 @@ public class RaidConfig {
     public int RAID_SPAWN_RADIUS = 450;
 
     @Setting("town-raid-creation-distance")
-    public int RAID_MIN_CREATION_DISTANCE = 180;
+    public int RAID_MIN_CREATION_DISTANCE = 20;
 
     @Setting("town-raid-creation-distance")
     public int RAID_MAX_CREATION_DISTANCE = 500;

--- a/src/main/java/com/atherys/towns/config/RaidConfig.java
+++ b/src/main/java/com/atherys/towns/config/RaidConfig.java
@@ -22,12 +22,15 @@ public class RaidConfig {
     public double RAID_COST;
 
     @Setting("town-raid-spawn-radius")
-    public int RAID_SPAWN_RADIUS;
+    public int RAID_SPAWN_RADIUS = 50;
 
     @Setting("town-raid-creation-distance")
     public int RAID_CREATION_DISTANCE;
 
     @Setting("town-raid-damage-per-spawn")
     public int RAID_DAMAGE_PER_SPAWN = 50;
+
+    @Setting("town-raid-skin-uuid")
+    public String RAID_SKIN_UUID = "b1759db2-3b7f-4d5d-9155-70aca6e94cba";
 
 }

--- a/src/main/java/com/atherys/towns/config/RaidConfig.java
+++ b/src/main/java/com/atherys/towns/config/RaidConfig.java
@@ -24,10 +24,10 @@ public class RaidConfig {
     @Setting("town-raid-spawn-radius")
     public int RAID_SPAWN_RADIUS = 450;
 
-    @Setting("town-raid-creation-distance")
+    @Setting("town-raid-min-creation-distance")
     public int RAID_MIN_CREATION_DISTANCE = 20;
 
-    @Setting("town-raid-creation-distance")
+    @Setting("town-raid-max-creation-distance")
     public int RAID_MAX_CREATION_DISTANCE = 500;
 
     @Setting("town-raid-damage-per-spawn")

--- a/src/main/java/com/atherys/towns/config/RaidConfig.java
+++ b/src/main/java/com/atherys/towns/config/RaidConfig.java
@@ -25,7 +25,10 @@ public class RaidConfig {
     public int RAID_SPAWN_RADIUS = 450;
 
     @Setting("town-raid-creation-distance")
-    public int RAID_CREATION_DISTANCE = 180;
+    public int RAID_MIN_CREATION_DISTANCE = 180;
+
+    @Setting("town-raid-creation-distance")
+    public int RAID_MAX_CREATION_DISTANCE = 500;
 
     @Setting("town-raid-damage-per-spawn")
     public int RAID_DAMAGE_PER_SPAWN = 50;

--- a/src/main/java/com/atherys/towns/config/RaidConfig.java
+++ b/src/main/java/com/atherys/towns/config/RaidConfig.java
@@ -33,6 +33,9 @@ public class RaidConfig {
     @Setting("town-raid-damage-per-spawn")
     public int RAID_DAMAGE_PER_SPAWN = 50;
 
+    @Setting("town-raid-distance-between-points")
+    public int RAID_DISTANCE_BETWEEN_POINTS = 150;
+
     @Setting("town-raid-skin-uuid")
     public String RAID_SKIN_UUID = "b1759db2-3b7f-4d5d-9155-70aca6e94cba";
 

--- a/src/main/java/com/atherys/towns/config/RaidConfig.java
+++ b/src/main/java/com/atherys/towns/config/RaidConfig.java
@@ -10,7 +10,7 @@ import java.time.temporal.ChronoUnit;
 public class RaidConfig {
 
     @Setting("town-raid-health")
-    public double RAID_HEALTH = 1024.00;
+    public double RAID_HEALTH = 500.00;
 
     @Setting("town-raid-duration")
     public Duration RAID_DURATION = Duration.of(1, ChronoUnit.MINUTES);
@@ -19,13 +19,13 @@ public class RaidConfig {
     public Duration RAID_COOLDOWN = Duration.of(1, ChronoUnit.MINUTES);
 
     @Setting("town-raid-cost")
-    public double RAID_COST;
+    public double RAID_COST = 500.00;
 
     @Setting("town-raid-spawn-radius")
-    public int RAID_SPAWN_RADIUS = 50;
+    public int RAID_SPAWN_RADIUS = 450;
 
     @Setting("town-raid-creation-distance")
-    public int RAID_CREATION_DISTANCE;
+    public int RAID_CREATION_DISTANCE = 180;
 
     @Setting("town-raid-damage-per-spawn")
     public int RAID_DAMAGE_PER_SPAWN = 50;

--- a/src/main/java/com/atherys/towns/config/RaidConfig.java
+++ b/src/main/java/com/atherys/towns/config/RaidConfig.java
@@ -36,6 +36,9 @@ public class RaidConfig {
     @Setting("town-raid-distance-between-points")
     public int RAID_DISTANCE_BETWEEN_POINTS = 150;
 
+    @Setting("town-raid-boss-bar-distance")
+    public int RAID_BOSS_BAR_DISTANCE = 20;
+
     @Setting("town-raid-skin-uuid")
     public String RAID_SKIN_UUID = "b1759db2-3b7f-4d5d-9155-70aca6e94cba";
 

--- a/src/main/java/com/atherys/towns/config/RaidConfig.java
+++ b/src/main/java/com/atherys/towns/config/RaidConfig.java
@@ -1,0 +1,29 @@
+package com.atherys.towns.config;
+
+import ninja.leaping.configurate.objectmapping.Setting;
+import ninja.leaping.configurate.objectmapping.serialize.ConfigSerializable;
+
+import java.time.Duration;
+
+@ConfigSerializable
+public class RaidConfig {
+
+    @Setting("town-raid-health")
+    public int RAID_HEALTH = 1024;
+
+    @Setting("town-raid-duration")
+    public Duration RAID_DURATION;
+
+    @Setting("town-raid-cooldown")
+    public Duration RAID_COOLDOWN;
+
+    @Setting("town-raid-cost")
+    public double RAID_COST;
+
+    @Setting("town-raid-spawn-radius")
+    public int RAID_SPAWN_RADIUS;
+
+    @Setting("town-raid-creation-distance")
+    public int RAID_CREATION_DISTANCE;
+
+}

--- a/src/main/java/com/atherys/towns/config/TownConfig.java
+++ b/src/main/java/com/atherys/towns/config/TownConfig.java
@@ -47,6 +47,8 @@ public class TownConfig {
         townLeader.setName("Mayor");
         townLeader.setTownPermissions(ImmutableSet.of(
                 TownPermissions.RUIN_TOWN,
+                TownPermissions.START_RAID,
+                TownPermissions.CANCEL_RAID,
                 TownPermissions.INVITE_RESIDENT,
                 TownPermissions.KICK_RESIDENT,
                 TownPermissions.CLAIM_PLOT,

--- a/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
+++ b/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
@@ -156,7 +156,7 @@ public class TownRaidFacade {
         return Text.of(GOLD, "x: ", location.getBlockX(), ", y: ", location.getBlockY(), ", z: ", location.getBlockZ());
     }
 
-    private Text formatDurationLeft(LocalDateTime time, Duration duration) {
+    public Text formatDurationLeft(LocalDateTime time, Duration duration) {
         Duration durationBetweenPresent = Duration.between(time, LocalDateTime.now());
         Duration durationLeft = duration.minus(durationBetweenPresent);
         if (durationLeft.toMinutes() >= 1) {
@@ -233,11 +233,11 @@ public class TownRaidFacade {
     }
 
     public void onRaidPointDeath(DestructEntityEvent.Death event) {
-        RaidPoint point = townRaidService.getRaidPoint(event.getTargetEntity().getUniqueId());
+        UUID raidPointUUID = event.getTargetEntity().getUniqueId();
+        RaidPoint point = townRaidService.getRaidPoint(raidPointUUID);
         townFacade.getOnlineTownMembers(point.getRaidingTown()).forEach(member -> townsMsg.info(member, "Your mage has been killed!"));
         point.getParticleUUIDs().forEach(uuid -> townRaidService.removeEntity(point.getPointTransform().getExtent(), uuid));
-        //TODO: Add logic to remove boss bar from players
-        townRaidService.removeRaidPoint(point.getRaidPointUUID());
+        townRaidService.removeRaidPoint(raidPointUUID);
     }
 
     public boolean onPlayerSpawn(RespawnPlayerEvent event) {

--- a/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
+++ b/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
@@ -99,7 +99,7 @@ public class TownRaidFacade {
         }
 
         if (townRaidService.isLocationTaken(location)) {
-            throw new TownsCommandException("This location is already occupied by another town's raid point!");
+            throw new TownsCommandException("This location is too close to another town's raid point!");
         }
 
         if (!townRaidService.hasCooldownPeriodPassed(town)) {

--- a/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
+++ b/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
@@ -14,6 +14,7 @@ import com.atherys.towns.util.MathUtils;
 import com.flowpowered.math.vector.Vector3d;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.slf4j.Logger;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.effect.particle.ParticleType;
@@ -67,12 +68,15 @@ public class TownRaidFacade {
         return townRaidService.isIdRaidEntity(entity.getUniqueId());
     }
 
-    public boolean isTownTooClose(Transform<World> targetSpawn, Location<World> spawnLocation) {
-        return MathUtils.getDistanceBetweenPoints(spawnLocation.getPosition(), targetSpawn.getPosition()) <= config.RAID.RAID_MIN_CREATION_DISTANCE;
+    public boolean isTownTooClose(Town town, Location<World> spawnLocation) {
+        Logger logger = AtherysTowns.getInstance().getLogger();
+        double test = MathUtils.getSmallestDistanceToTown(town.getPlots(), MathUtils.vec3dToVec2i(spawnLocation.getPosition()));
+        logger.info(String.valueOf(test));
+        return test <= config.RAID.RAID_MIN_CREATION_DISTANCE;
     }
 
-    public boolean isTownTooFarAway(Transform<World> targetSpawn, Location<World> spawnLocation) {
-        return MathUtils.getDistanceBetweenPoints(spawnLocation.getPosition(), targetSpawn.getPosition()) >= config.RAID.RAID_MAX_CREATION_DISTANCE;
+    public boolean isTownTooFarAway(Town town, Location<World> spawnLocation) {
+        return MathUtils.getSmallestDistanceToTown(town.getPlots(), MathUtils.vec3dToVec2i(spawnLocation.getPosition())) >= config.RAID.RAID_MAX_CREATION_DISTANCE;
     }
 
     public boolean isPlayerCloseToRaid(Transform<World> targetSpawn, Transform<World> spawnLocation) {
@@ -106,11 +110,11 @@ public class TownRaidFacade {
             throw new TownsCommandException("Raid Cooldown is still in effect!");
         }
 
-        if (isTownTooClose(targetTown.getSpawn(), location)) {
+        if (isTownTooClose(town, location)) {
             throw new TownsCommandException("Target town is too close to current location!");
         }
 
-        if (isTownTooFarAway(targetTown.getSpawn(), location)) {
+        if (isTownTooFarAway(town, location)) {
             throw new TownsCommandException("Target town is too far away from current location!");
         }
 

--- a/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
+++ b/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
@@ -1,0 +1,145 @@
+package com.atherys.towns.facade;
+
+import com.atherys.core.economy.Economy;
+import com.atherys.towns.AtherysTowns;
+import com.atherys.towns.TownsConfig;
+import com.atherys.towns.api.command.TownsCommandException;
+import com.atherys.towns.config.RaidConfig;
+import com.atherys.towns.model.RaidPoint;
+import com.atherys.towns.model.entity.Plot;
+import com.atherys.towns.model.entity.Resident;
+import com.atherys.towns.model.entity.Town;
+import com.atherys.towns.service.TownService;
+import com.flowpowered.math.vector.Vector3d;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import net.bytebuddy.asm.Advice;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.EntityTypes;
+import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.service.economy.account.Account;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalUnit;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.spongepowered.api.text.format.TextColors.*;
+
+@Singleton
+public class TownRaidFacade {
+
+    @Inject
+    TownsConfig config;
+
+    @Inject
+    TownFacade townFacade;
+
+    @Inject
+    TownsMessagingFacade townsMsg;
+
+    Map<Town, RaidPoint> activeRaids = new HashMap<>();
+
+    public TownRaidFacade(){
+
+    }
+
+    public void updateRaidHealth(Town town, int damage) {
+        RaidPoint point = activeRaids.get(town);
+        point.setHealth(point.getHealth() - damage);
+    }
+
+    public boolean hasCooldownPeriodPassed(Town town) {
+        if(town.getLastRaidCreationDate() != null) {
+            return Duration.between(town.getLastRaidCreationDate(), LocalDateTime.now()).compareTo(config.RAID.RAID_COOLDOWN) >= 0;
+        }
+        return true;
+    }
+
+    public void validateRaid(Player player, Town town) throws TownsCommandException {
+        Location<World> location = player.getLocation();
+        RaidConfig raidConfig = config.RAID;
+
+        if(AtherysTowns.economyIsEnabled()) {
+            Optional<Account> townBank = Economy.getAccount(town.getBank().toString());
+            if(townBank.isPresent() && townBank.get().getBalance(config.DEFAULT_CURRENCY).doubleValue() < raidConfig.RAID_COST) {
+                throw new TownsCommandException("Your town bank does not have enough money to create a raid point!");
+            }
+        }
+
+        if(activeRaids.containsKey(town)) {
+            throw new TownsCommandException("Your town already has an active raid point!");
+        }
+
+        if(activeRaids.values().stream().anyMatch(raidPoint -> raidPoint.getPointLocation() == location)) {
+            throw new TownsCommandException("This location is already occupied by another town's raid point!");
+        }
+
+        if(!hasCooldownPeriodPassed(town)) {
+            throw new TownsCommandException("Raid Cooldown is still in effect!");
+        }
+
+    }
+
+    public Location<World> getRaidPointLocation(Player player) {
+        return player.getLocation().asHighestLocation();
+    }
+
+    public void spawnRaidPoint(Location<World> location, Player player) {
+        Vector3d pointLocation = new Vector3d(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+        Entity entity = player.getWorld().createEntity(EntityTypes.ARMOR_STAND, pointLocation);
+        player.getWorld().spawnEntity(entity);
+    }
+
+    public void createRaidPoint(Player player) throws TownsCommandException {
+        Town town = townFacade.getPlayerTown(player);
+        validateRaid(player, town);
+
+        RaidPoint point = new RaidPoint(LocalDateTime.now(), getRaidPointLocation(player), config.RAID.RAID_HEALTH);
+        activeRaids.put(town, point);
+        spawnRaidPoint(point.getPointLocation(), player);
+        townFacade.getOnlineTownMembers(town).forEach(member -> townsMsg.info(member, "A town raid point has been spawned!"));
+    }
+
+    private Text formatRaidLocation(Location<World> location) {
+        return Text.of(GOLD, "x: ", location.getBlockX(), ", y: ", location.getBlockY(), ", z: ", location.getBlockZ());
+    }
+
+    private Text formatDurationLeft(Town town, LocalDateTime time, Duration duration) {
+        Duration durationBetweenPresent = Duration.between(time, LocalDateTime.now());
+        Duration durationLeft = duration.minus(durationBetweenPresent);
+        return Text.of(GOLD, durationLeft.toMinutes());
+    }
+
+    public void sendRaidPointInfo(Player player) throws TownsCommandException {
+        Town town = townFacade.getPlayerTown(player);
+        boolean raidExists = activeRaids.containsKey(town);
+        Text status = raidExists ? Text.of(GREEN, "True") : Text.of(RED, "False");
+        Text pointLocation = raidExists ? formatRaidLocation(activeRaids.get(town).getPointLocation()) : Text.of(RED, "No Raid in Progress");
+        Text pointHealth = raidExists ? Text.of(GOLD, activeRaids.get(town).getHealth()) : Text.of(RED, "No Raid in Progress");
+        Text durationLeft = raidExists ? formatDurationLeft(town, activeRaids.get(town).getCreationTime(), config.RAID.RAID_DURATION) : Text.of(RED, "No Raid in Progress");
+        Text cooldown = hasCooldownPeriodPassed(town) ? Text.of(GREEN, "No Cooldown Remaining") : formatDurationLeft(town, town.getLastRaidCreationDate(), config.RAID.RAID_COOLDOWN);
+
+        Text.Builder raidText = Text.builder();
+
+        raidText
+                .append(townsMsg.createTownsHeader("Raid Point"));
+
+        raidText
+                .append(Text.of(DARK_GREEN, "Raid in Progress: ", status, Text.NEW_LINE))
+                .append(Text.of(DARK_GREEN, "Raid Location: ", pointLocation, Text.NEW_LINE))
+                .append(Text.of(DARK_GREEN, "Point Health: ", pointHealth, Text.NEW_LINE))
+                .append(Text.of(DARK_GREEN, "Duration Left: ", durationLeft, Text.NEW_LINE))
+                .append(Text.of(DARK_GREEN, "Cooldown: ", cooldown));
+
+        player.sendMessage(raidText.build());
+    }
+
+
+}

--- a/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
+++ b/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
@@ -236,6 +236,7 @@ public class TownRaidFacade {
         RaidPoint point = townRaidService.getRaidPoint(event.getTargetEntity().getUniqueId());
         townFacade.getOnlineTownMembers(point.getRaidingTown()).forEach(member -> townsMsg.info(member, "Your mage has been killed!"));
         point.getParticleUUIDs().forEach(uuid -> townRaidService.removeEntity(point.getPointTransform().getExtent(), uuid));
+        //TODO: Add logic to remove boss bar from players
         townRaidService.removeRaidPoint(point.getRaidPointUUID());
     }
 

--- a/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
+++ b/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
@@ -70,7 +70,7 @@ public class TownRaidFacade {
 
     public void checkDistanceToTown(Town town, Vector3d targetPoint) throws TownsCommandException {
         for (Plot plot : town.getPlots()) {
-            double plotDistance = MathUtils.getDistanceToPlot(MathUtils.vec3dToVec2i(targetPoint), plot.getNorthEastCorner(), plot.getSouthWestCorner());
+            double plotDistance = MathUtils.getDistanceToPlotSquared(MathUtils.vec3dToVec2i(targetPoint), plot.getNorthEastCorner(), plot.getSouthWestCorner());
             if (plotDistance < Math.pow(config.RAID.RAID_MIN_CREATION_DISTANCE, 2)) {
                 throw new TownsCommandException("Target town is too close to current location!");
             }
@@ -82,7 +82,7 @@ public class TownRaidFacade {
     }
 
     public boolean isPlayerCloseToRaid(Transform<World> targetSpawn, Transform<World> spawnLocation) {
-        return MathUtils.getDistanceBetweenPoints(spawnLocation.getPosition(), targetSpawn.getPosition()) <= config.RAID.RAID_SPAWN_RADIUS;
+        return MathUtils.getDistanceBetweenPointsSquared(spawnLocation.getPosition(), targetSpawn.getPosition()) <= Math.pow(config.RAID.RAID_SPAWN_RADIUS, 2);
     }
 
     public void validateRaid(Town town, Transform<World> transform, Town targetTown) throws TownsCommandException {
@@ -172,7 +172,7 @@ public class TownRaidFacade {
         Text pointLocation = raidExists ? formatRaidLocation(point.get().getPointTransform()) : Text.of(RED, "No Raid in Progress");
         Text pointHealth = raidExists ? Text.of(GOLD, townRaidService.getRaidHealth(player.getWorld(), point.get())) : Text.of(RED, "No Raid in Progress");
         Text durationLeft = raidExists ? formatDurationLeft(point.get().getCreationTime(), config.RAID.RAID_DURATION) : Text.of(RED, "No Raid in Progress");
-        Text cooldown = townRaidService.hasCooldownPeriodPassed(town) ? Text.of(GREEN, "No Cooldown Remaining") : formatDurationLeft(town.getLastRaidCreationDate(), config.RAID.RAID_COOLDOWN);
+        Text cooldown = townRaidService.hasCooldownPeriodPassed(town) ? Text.of(GREEN, "No Cooldown Remaining") : formatDurationLeft(town.getLastRaidCreationDate().get(), config.RAID.RAID_COOLDOWN);
 
         Text.Builder raidText = Text.builder();
 

--- a/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
+++ b/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
@@ -34,10 +34,7 @@ import org.spongepowered.api.world.World;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import static org.spongepowered.api.text.format.TextColors.*;
 
@@ -80,11 +77,10 @@ public class TownRaidFacade {
 
     public void validateRaid(Town town, Transform<World> transform, Town targetTown) throws TownsCommandException {
         Location<World> location = transform.getLocation();
-        RaidConfig raidConfig = config.RAID;
 
         if (AtherysTowns.economyIsEnabled()) {
             Optional<Account> townBank = Economy.getAccount(town.getBank().toString());
-            if (townBank.isPresent() && townBank.get().getBalance(config.DEFAULT_CURRENCY).doubleValue() < raidConfig.RAID_COST) {
+            if (townBank.isPresent() && townBank.get().getBalance(config.DEFAULT_CURRENCY).doubleValue() < config.RAID.RAID_COST) {
                 throw new TownsCommandException("Your town bank does not have enough money to create a raid point!");
             }
         }
@@ -125,10 +121,7 @@ public class TownRaidFacade {
         player.getWorld().spawnEntity(cloud1);
         player.getWorld().spawnEntity(cloud2);
 
-        Set<UUID> particleSet = new HashSet<>();
-        particleSet.add(cloud1.getUniqueId());
-        particleSet.add(cloud2.getUniqueId());
-        return particleSet;
+        return new HashSet<>(Arrays.asList(cloud1.getUniqueId(), cloud2.getUniqueId()));
     }
 
     public UUID spawnRaidPoint(Transform<World> transform, Player player) {

--- a/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
+++ b/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
@@ -77,8 +77,8 @@ public class TownRaidFacade {
             if (plotDistance < config.RAID.RAID_MAX_CREATION_DISTANCE) {
                 return;
             }
-            throw new TownsCommandException("Target town is too far away from current location!");
         }
+        throw new TownsCommandException("Target town is too far away from current location!");
     }
 
     public boolean isPlayerCloseToRaid(Transform<World> targetSpawn, Transform<World> spawnLocation) {

--- a/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
+++ b/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
@@ -71,10 +71,10 @@ public class TownRaidFacade {
     public void checkDistanceToTown(Town town, Vector3d targetPoint) throws TownsCommandException {
         for (Plot plot : town.getPlots()) {
             double plotDistance = MathUtils.getDistanceToPlot(MathUtils.vec3dToVec2i(targetPoint), plot.getNorthEastCorner(), plot.getSouthWestCorner());
-            if (plotDistance < config.RAID.RAID_MIN_CREATION_DISTANCE) {
+            if (plotDistance < Math.pow(config.RAID.RAID_MIN_CREATION_DISTANCE, 2)) {
                 throw new TownsCommandException("Target town is too close to current location!");
             }
-            if (plotDistance < config.RAID.RAID_MAX_CREATION_DISTANCE) {
+            if (plotDistance < Math.pow(config.RAID.RAID_MAX_CREATION_DISTANCE, 2)) {
                 return;
             }
         }

--- a/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
+++ b/src/main/java/com/atherys/towns/facade/TownRaidFacade.java
@@ -9,14 +9,24 @@ import com.atherys.towns.model.RaidPoint;
 import com.atherys.towns.model.entity.Plot;
 import com.atherys.towns.model.entity.Resident;
 import com.atherys.towns.model.entity.Town;
+import com.atherys.towns.service.ResidentService;
+import com.atherys.towns.service.TownRaidService;
 import com.atherys.towns.service.TownService;
 import com.flowpowered.math.vector.Vector3d;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import net.bytebuddy.asm.Advice;
+import org.slf4j.Logger;
+import org.spongepowered.api.data.DataTransactionResult;
+import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.EntityTypes;
+import org.spongepowered.api.entity.Transform;
+import org.spongepowered.api.entity.living.Living;
 import org.spongepowered.api.entity.living.player.Player;
+import org.spongepowered.api.event.entity.DamageEntityEvent;
+import org.spongepowered.api.event.entity.DestructEntityEvent;
+import org.spongepowered.api.event.entity.living.humanoid.player.RespawnPlayerEvent;
 import org.spongepowered.api.service.economy.account.Account;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColors;
@@ -29,6 +39,7 @@ import java.time.temporal.TemporalUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.spongepowered.api.text.format.TextColors.*;
 
@@ -44,15 +55,18 @@ public class TownRaidFacade {
     @Inject
     TownsMessagingFacade townsMsg;
 
-    Map<Town, RaidPoint> activeRaids = new HashMap<>();
+    @Inject
+    TownRaidService townRaidService;
+
+    @Inject
+    ResidentService residentService;
 
     public TownRaidFacade(){
 
     }
 
-    public void updateRaidHealth(Town town, int damage) {
-        RaidPoint point = activeRaids.get(town);
-        point.setHealth(point.getHealth() - damage);
+    public boolean isEntityRaidPoint(Entity entity) {
+        return townRaidService.isIdRaidEntity(entity.getUniqueId());
     }
 
     public boolean hasCooldownPeriodPassed(Town town) {
@@ -73,45 +87,38 @@ public class TownRaidFacade {
             }
         }
 
-        if(activeRaids.containsKey(town)) {
+        if(townRaidService.isTownRaidActive(town)) {
             throw new TownsCommandException("Your town already has an active raid point!");
         }
 
-        if(activeRaids.values().stream().anyMatch(raidPoint -> raidPoint.getPointLocation() == location)) {
+        if(townRaidService.isLocationTaken(location)) {
             throw new TownsCommandException("This location is already occupied by another town's raid point!");
         }
 
         if(!hasCooldownPeriodPassed(town)) {
             throw new TownsCommandException("Raid Cooldown is still in effect!");
         }
-
     }
 
-    public Location<World> getRaidPointLocation(Player player) {
-        return player.getLocation().asHighestLocation();
-    }
+    public UUID spawnRaidPoint(Transform<World> location, Player player) {
+        Entity entity = player.getWorld().createEntity(EntityTypes.HUMAN, location.getPosition());
 
-    public void spawnRaidPoint(Location<World> location, Player player) {
-        Vector3d pointLocation = new Vector3d(location.getBlockX(), location.getBlockY(), location.getBlockZ());
-        Entity entity = player.getWorld().createEntity(EntityTypes.ARMOR_STAND, pointLocation);
+        entity.offer(Keys.AI_ENABLED, false);
+        entity.offer(Keys.DISPLAY_NAME, Text.of("Hired Mage"));
+        entity.offer(Keys.MAX_HEALTH, config.RAID.RAID_HEALTH);
+        entity.offer(Keys.HEALTH, config.RAID.RAID_HEALTH);
+
         player.getWorld().spawnEntity(entity);
+
+        return entity.getUniqueId();
     }
 
-    public void createRaidPoint(Player player) throws TownsCommandException {
-        Town town = townFacade.getPlayerTown(player);
-        validateRaid(player, town);
-
-        RaidPoint point = new RaidPoint(LocalDateTime.now(), getRaidPointLocation(player), config.RAID.RAID_HEALTH);
-        activeRaids.put(town, point);
-        spawnRaidPoint(point.getPointLocation(), player);
-        townFacade.getOnlineTownMembers(town).forEach(member -> townsMsg.info(member, "A town raid point has been spawned!"));
-    }
-
-    private Text formatRaidLocation(Location<World> location) {
+    private Text formatRaidLocation(Transform<World> transform) {
+        Location<World> location = transform.getLocation();
         return Text.of(GOLD, "x: ", location.getBlockX(), ", y: ", location.getBlockY(), ", z: ", location.getBlockZ());
     }
 
-    private Text formatDurationLeft(Town town, LocalDateTime time, Duration duration) {
+    private Text formatDurationLeft(LocalDateTime time, Duration duration) {
         Duration durationBetweenPresent = Duration.between(time, LocalDateTime.now());
         Duration durationLeft = duration.minus(durationBetweenPresent);
         return Text.of(GOLD, durationLeft.toMinutes());
@@ -119,12 +126,13 @@ public class TownRaidFacade {
 
     public void sendRaidPointInfo(Player player) throws TownsCommandException {
         Town town = townFacade.getPlayerTown(player);
-        boolean raidExists = activeRaids.containsKey(town);
+        boolean raidExists = townRaidService.isTownRaidActive(town);
+        RaidPoint point = townRaidService.getTownRaidPoint(town);
         Text status = raidExists ? Text.of(GREEN, "True") : Text.of(RED, "False");
-        Text pointLocation = raidExists ? formatRaidLocation(activeRaids.get(town).getPointLocation()) : Text.of(RED, "No Raid in Progress");
-        Text pointHealth = raidExists ? Text.of(GOLD, activeRaids.get(town).getHealth()) : Text.of(RED, "No Raid in Progress");
-        Text durationLeft = raidExists ? formatDurationLeft(town, activeRaids.get(town).getCreationTime(), config.RAID.RAID_DURATION) : Text.of(RED, "No Raid in Progress");
-        Text cooldown = hasCooldownPeriodPassed(town) ? Text.of(GREEN, "No Cooldown Remaining") : formatDurationLeft(town, town.getLastRaidCreationDate(), config.RAID.RAID_COOLDOWN);
+        Text pointLocation = raidExists ? formatRaidLocation(point.getPointTransform()) : Text.of(RED, "No Raid in Progress");
+        Text pointHealth = raidExists ? Text.of(GOLD, point.getHealth()) : Text.of(RED, "No Raid in Progress");
+        Text durationLeft = raidExists ? formatDurationLeft(point.getCreationTime(), config.RAID.RAID_DURATION) : Text.of(RED, "No Raid in Progress");
+        Text cooldown = hasCooldownPeriodPassed(town) ? Text.of(GREEN, "No Cooldown Remaining") : formatDurationLeft(town.getLastRaidCreationDate(), config.RAID.RAID_COOLDOWN);
 
         Text.Builder raidText = Text.builder();
 
@@ -139,6 +147,42 @@ public class TownRaidFacade {
                 .append(Text.of(DARK_GREEN, "Cooldown: ", cooldown));
 
         player.sendMessage(raidText.build());
+    }
+
+    public Transform<World> getRaidPointTransform(Player player) {
+        Location<World> highLocation = player.getLocation().asHighestLocation();
+        return player.getTransform().setLocation(highLocation);
+    }
+
+    public void createRaidPoint(Player player) throws TownsCommandException{
+        Town town = townFacade.getPlayerTown(player);
+        validateRaid(player, town);
+        Transform<World> transform = getRaidPointTransform(player);
+
+        UUID entityId = spawnRaidPoint(transform, player);
+        townRaidService.createRaidPointEntry(getRaidPointTransform(player), town, entityId);
+
+        townFacade.getOnlineTownMembers(town).forEach(member -> townsMsg.info(member, "A town raid point has been spawned!"));
+    }
+
+    public void onRaidPointDeath(DestructEntityEvent.Death event) {
+        RaidPoint point = townRaidService.getRaidPointByEntity(event.getTargetEntity().getUniqueId());
+        townRaidService.removeRaidPoint(point);
+    }
+
+    public void onDamageRaidPoint(DamageEntityEvent event) {
+        RaidPoint raidPoint = townRaidService.getRaidPointByEntity(event.getTargetEntity().getUniqueId());
+        townRaidService.updateRaidHealth(raidPoint.getRaidingTown(), event.getFinalDamage());
+    }
+
+    public boolean onPlayerSpawn(RespawnPlayerEvent event) {
+        Town town = residentService.getOrCreate(event.getOriginalPlayer()).getTown();
+        if(townRaidService.isTownRaidActive(town)) {
+            event.setToTransform(townRaidService.getTownRaidPoint(town).getPointTransform());
+            townRaidService.updateRaidHealth(town, config.RAID.RAID_DAMAGE_PER_SPAWN);
+            return true;
+        }
+        return false;
     }
 
 

--- a/src/main/java/com/atherys/towns/listener/PlayerListener.java
+++ b/src/main/java/com/atherys/towns/listener/PlayerListener.java
@@ -40,6 +40,9 @@ public class PlayerListener {
     @Inject
     private PlotBorderFacade plotBorderFacade;
 
+    @Inject
+    private TownRaidFacade townRaidFacade;
+
     @Listener
     public void onPlayerMove(MoveEntityEvent event, @Root Player player) {
         // And the move event was triggered due to a change in block position
@@ -52,7 +55,7 @@ public class PlayerListener {
 
     @Listener
     public void onPlayerSpawn(RespawnPlayerEvent event) {
-        if (config.SPAWN_IN_TOWN) {
+        if (!townRaidFacade.onPlayerSpawn(event) && config.SPAWN_IN_TOWN) {
             residentFacade.onPlayerSpawn(event);
         }
     }

--- a/src/main/java/com/atherys/towns/listener/RaidListener.java
+++ b/src/main/java/com/atherys/towns/listener/RaidListener.java
@@ -1,0 +1,21 @@
+package com.atherys.towns.listener;
+
+import com.atherys.towns.facade.TownRaidFacade;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.spongepowered.api.event.Listener;
+import org.spongepowered.api.event.entity.DestructEntityEvent;
+
+@Singleton
+public class RaidListener {
+
+    @Inject
+    TownRaidFacade townRaidFacade;
+
+    @Listener
+    public void onRaidPointDeath(DestructEntityEvent.Death event) {
+        if (townRaidFacade.isEntityRaidPoint(event.getTargetEntity())) {
+            townRaidFacade.onRaidPointDeath(event);
+        }
+    }
+}

--- a/src/main/java/com/atherys/towns/model/RaidPoint.java
+++ b/src/main/java/com/atherys/towns/model/RaidPoint.java
@@ -5,6 +5,7 @@ import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.world.World;
 
 import java.time.LocalDateTime;
+import java.util.Set;
 import java.util.UUID;
 
 public class RaidPoint {
@@ -15,13 +16,16 @@ public class RaidPoint {
 
     private UUID raidPointUUID;
 
+    private Set<UUID> particleUUIDs;
+
     private Town raidingTown;
 
-    public RaidPoint(LocalDateTime creationTime, Transform<World> location, UUID entityId, Town town) {
+    public RaidPoint(LocalDateTime creationTime, Transform<World> location, UUID entityId, Town town, Set<UUID> particleUUIDs) {
         this.pointTransform = location;
         this.creationTime = creationTime;
         this.raidPointUUID = entityId;
         this.raidingTown = town;
+        this.particleUUIDs = particleUUIDs;
     }
 
     public Transform<World> getPointTransform() {
@@ -54,5 +58,13 @@ public class RaidPoint {
 
     public void setRaidingTown(Town town) {
         this.raidingTown = town;
+    }
+
+    public Set<UUID> getParticleUUIDs() {
+        return this.particleUUIDs;
+    }
+
+    public void setParticleUUIDs(Set<UUID> particleUUIDs) {
+        this.particleUUIDs = particleUUIDs;
     }
 }

--- a/src/main/java/com/atherys/towns/model/RaidPoint.java
+++ b/src/main/java/com/atherys/towns/model/RaidPoint.java
@@ -1,6 +1,7 @@
 package com.atherys.towns.model;
 
 import com.atherys.towns.model.entity.Town;
+import org.spongepowered.api.boss.ServerBossBar;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.world.World;
 
@@ -22,13 +23,17 @@ public class RaidPoint {
 
     private Town targetTown;
 
-    public RaidPoint(LocalDateTime creationTime, Transform<World> location, UUID entityId, Town raidingTown, Town targetTown, Set<UUID> particleUUIDs) {
+    private ServerBossBar raidBossBar;
+
+    public RaidPoint(LocalDateTime creationTime, Transform<World> location, UUID entityId, Town raidingTown,
+                     Town targetTown, Set<UUID> particleUUIDs, ServerBossBar raidBossBar) {
         this.pointTransform = location;
         this.creationTime = creationTime;
         this.raidPointUUID = entityId;
         this.raidingTown = raidingTown;
         this.targetTown = targetTown;
         this.particleUUIDs = particleUUIDs;
+        this.raidBossBar = raidBossBar;
     }
 
     public Transform<World> getPointTransform() {
@@ -77,5 +82,13 @@ public class RaidPoint {
 
     public void setParticleUUIDs(Set<UUID> particleUUIDs) {
         this.particleUUIDs = particleUUIDs;
+    }
+
+    public ServerBossBar getRaidBossBar() {
+        return this.raidBossBar;
+    }
+
+    public void setRaidBossBar(ServerBossBar raidBossBar) {
+        this.raidBossBar = raidBossBar;
     }
 }

--- a/src/main/java/com/atherys/towns/model/RaidPoint.java
+++ b/src/main/java/com/atherys/towns/model/RaidPoint.java
@@ -20,11 +20,14 @@ public class RaidPoint {
 
     private Town raidingTown;
 
-    public RaidPoint(LocalDateTime creationTime, Transform<World> location, UUID entityId, Town town, Set<UUID> particleUUIDs) {
+    private Town targetTown;
+
+    public RaidPoint(LocalDateTime creationTime, Transform<World> location, UUID entityId, Town raidingTown, Town targetTown, Set<UUID> particleUUIDs) {
         this.pointTransform = location;
         this.creationTime = creationTime;
         this.raidPointUUID = entityId;
-        this.raidingTown = town;
+        this.raidingTown = raidingTown;
+        this.targetTown = targetTown;
         this.particleUUIDs = particleUUIDs;
     }
 
@@ -58,6 +61,14 @@ public class RaidPoint {
 
     public void setRaidingTown(Town town) {
         this.raidingTown = town;
+    }
+
+    public Town getTargetTown() {
+        return this.targetTown;
+    }
+
+    public void setTargetTown(Town targetTown) {
+        this.targetTown = targetTown;
     }
 
     public Set<UUID> getParticleUUIDs() {

--- a/src/main/java/com/atherys/towns/model/RaidPoint.java
+++ b/src/main/java/com/atherys/towns/model/RaidPoint.java
@@ -1,0 +1,47 @@
+package com.atherys.towns.model;
+
+import com.atherys.towns.model.entity.Town;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public class RaidPoint {
+
+    private Location<World> pointLocation;
+
+    private LocalDateTime creationTime;
+
+    private int health;
+
+    public RaidPoint(LocalDateTime creationTime, Location<World> location, int health) {
+        this.pointLocation = location;
+        this.creationTime = creationTime;
+        this.health = health;
+    }
+
+    public Location<World> getPointLocation() {
+        return this.pointLocation;
+    }
+
+    public void setPointLocation(Location<World> pointLocation) {
+        this.pointLocation = pointLocation;
+    }
+
+    public LocalDateTime getCreationTime() {
+        return this.creationTime;
+    }
+
+    public void setCreationTime(LocalDateTime creationTime) {
+        this.creationTime = creationTime;
+    }
+
+    public int getHealth() {
+        return this.health;
+    }
+
+    public void setHealth(int health) {
+        this.health = health;
+    }
+}

--- a/src/main/java/com/atherys/towns/model/RaidPoint.java
+++ b/src/main/java/com/atherys/towns/model/RaidPoint.java
@@ -1,7 +1,7 @@
 package com.atherys.towns.model;
 
 import com.atherys.towns.model.entity.Town;
-import org.spongepowered.api.world.Location;
+import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.world.World;
 
 import java.time.LocalDateTime;
@@ -9,24 +9,30 @@ import java.util.UUID;
 
 public class RaidPoint {
 
-    private Location<World> pointLocation;
+    private Transform<World> pointTransform;
 
     private LocalDateTime creationTime;
 
-    private int health;
+    private UUID raidPointUUID;
 
-    public RaidPoint(LocalDateTime creationTime, Location<World> location, int health) {
-        this.pointLocation = location;
+    private double health;
+
+    private Town raidingTown;
+
+    public RaidPoint(LocalDateTime creationTime, Transform<World> location, double health, UUID entityId, Town town) {
+        this.pointTransform = location;
         this.creationTime = creationTime;
         this.health = health;
+        this.raidPointUUID = entityId;
+        this.raidingTown = town;
     }
 
-    public Location<World> getPointLocation() {
-        return this.pointLocation;
+    public Transform<World> getPointTransform() {
+        return this.pointTransform;
     }
 
-    public void setPointLocation(Location<World> pointLocation) {
-        this.pointLocation = pointLocation;
+    public void setPointTransform(Transform<World> pointTransform) {
+        this.pointTransform = pointTransform;
     }
 
     public LocalDateTime getCreationTime() {
@@ -37,11 +43,27 @@ public class RaidPoint {
         this.creationTime = creationTime;
     }
 
-    public int getHealth() {
+    public double getHealth() {
         return this.health;
     }
 
-    public void setHealth(int health) {
+    public void setHealth(double health) {
         this.health = health;
+    }
+
+    public UUID getRaidPointUUID() {
+        return this.raidPointUUID;
+    }
+
+    public void setRaidPointUUID(UUID raidPointUUID) {
+        this.raidPointUUID = raidPointUUID;
+    }
+
+    public Town getRaidingTown() {
+        return this.raidingTown;
+    }
+
+    public void setRaidingTown(Town town) {
+        this.raidingTown = town;
     }
 }

--- a/src/main/java/com/atherys/towns/model/RaidPoint.java
+++ b/src/main/java/com/atherys/towns/model/RaidPoint.java
@@ -15,14 +15,11 @@ public class RaidPoint {
 
     private UUID raidPointUUID;
 
-    private double health;
-
     private Town raidingTown;
 
-    public RaidPoint(LocalDateTime creationTime, Transform<World> location, double health, UUID entityId, Town town) {
+    public RaidPoint(LocalDateTime creationTime, Transform<World> location, UUID entityId, Town town) {
         this.pointTransform = location;
         this.creationTime = creationTime;
-        this.health = health;
         this.raidPointUUID = entityId;
         this.raidingTown = town;
     }
@@ -41,14 +38,6 @@ public class RaidPoint {
 
     public void setCreationTime(LocalDateTime creationTime) {
         this.creationTime = creationTime;
-    }
-
-    public double getHealth() {
-        return this.health;
-    }
-
-    public void setHealth(double health) {
-        this.health = health;
     }
 
     public UUID getRaidPointUUID() {

--- a/src/main/java/com/atherys/towns/model/entity/Town.java
+++ b/src/main/java/com/atherys/towns/model/entity/Town.java
@@ -4,7 +4,6 @@ import com.atherys.core.db.Identifiable;
 import com.atherys.core.db.converter.TransformConverter;
 import com.atherys.towns.persistence.converter.TextColorConverter;
 import com.atherys.towns.persistence.converter.TextConverter;
-import net.bytebuddy.asm.Advice;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColor;
@@ -224,8 +223,8 @@ public class Town implements Identifiable<Long> {
         this.bank = bank;
     }
 
-    public LocalDateTime getLastRaidCreationDate() {
-        return this.lastRaidCreationDate;
+    public Optional<LocalDateTime> getLastRaidCreationDate() {
+        return Optional.ofNullable(this.lastRaidCreationDate);
     }
 
     public void setLastRaidCreationDate(LocalDateTime lastRaidCreationDate) {

--- a/src/main/java/com/atherys/towns/model/entity/Town.java
+++ b/src/main/java/com/atherys/towns/model/entity/Town.java
@@ -4,6 +4,7 @@ import com.atherys.core.db.Identifiable;
 import com.atherys.core.db.converter.TransformConverter;
 import com.atherys.towns.persistence.converter.TextColorConverter;
 import com.atherys.towns.persistence.converter.TextConverter;
+import net.bytebuddy.asm.Advice;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.text.format.TextColor;
@@ -11,6 +12,7 @@ import org.spongepowered.api.world.World;
 
 import javax.annotation.Nonnull;
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.*;
 
 @Entity
@@ -62,6 +64,8 @@ public class Town implements Identifiable<Long> {
     private boolean pvpEnabled;
 
     private UUID bank;
+
+    private LocalDateTime lastRaidCreationDate;
 
     @Version
     private int version;
@@ -218,6 +222,14 @@ public class Town implements Identifiable<Long> {
 
     public void setBank(UUID bank) {
         this.bank = bank;
+    }
+
+    public LocalDateTime getLastRaidCreationDate() {
+        return this.lastRaidCreationDate;
+    }
+
+    public void setLastRaidCreationDate(LocalDateTime lastRaidCreationDate) {
+        this.lastRaidCreationDate = lastRaidCreationDate;
     }
 
 }

--- a/src/main/java/com/atherys/towns/service/TownRaidService.java
+++ b/src/main/java/com/atherys/towns/service/TownRaidService.java
@@ -4,6 +4,7 @@ import com.atherys.towns.AtherysTowns;
 import com.atherys.towns.TownsConfig;
 import com.atherys.towns.model.RaidPoint;
 import com.atherys.towns.model.entity.Town;
+import com.atherys.towns.util.MathUtils;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.spongepowered.api.entity.Entity;
@@ -59,7 +60,7 @@ public class TownRaidService {
     }
 
     public boolean isLocationTaken(Location<World> location) {
-        return activeRaids.values().stream().anyMatch(raidPoint -> raidPoint.getPointTransform().getLocation() == location);
+        return activeRaids.values().stream().anyMatch(point -> MathUtils.getDistanceBetweenPoints(location.getPosition(), point.getPointTransform().getPosition()) < config.RAID.RAID_DISTANCE_BETWEEN_POINTS);
     }
 
     public boolean hasCooldownPeriodPassed(Town town) {

--- a/src/main/java/com/atherys/towns/service/TownRaidService.java
+++ b/src/main/java/com/atherys/towns/service/TownRaidService.java
@@ -106,21 +106,17 @@ public class TownRaidService {
     public boolean isLocationTaken(Location<World> location) {
         double raidDistance = Math.pow(config.RAID.RAID_DISTANCE_BETWEEN_POINTS, 2);
         return activeRaids.values().stream()
-                .anyMatch(point -> MathUtils.getDistanceBetweenPoints(location.getPosition(), point.getPointTransform().getPosition()) < raidDistance);
+                .anyMatch(point -> MathUtils.getDistanceBetweenPointsSquared(location.getPosition(), point.getPointTransform().getPosition()) < raidDistance);
     }
 
     public boolean hasCooldownPeriodPassed(Town town) {
-        if (town.getLastRaidCreationDate() != null) {
-            return Duration.between(town.getLastRaidCreationDate(), LocalDateTime.now()).compareTo(config.RAID.RAID_COOLDOWN) >= 0;
-        }
-        return true;
+        Optional<LocalDateTime> raidCreationDate = town.getLastRaidCreationDate();
+        return raidCreationDate.map(dateTime -> Duration.between(dateTime, LocalDateTime.now()).compareTo(config.RAID.RAID_COOLDOWN) >= 0).orElse(true);
     }
 
     public boolean hasDurationPassed(Town town) {
-        if (town.getLastRaidCreationDate() != null) {
-            return Duration.between(town.getLastRaidCreationDate(), LocalDateTime.now()).compareTo(config.RAID.RAID_DURATION) >= 0;
-        }
-        return true;
+        Optional<LocalDateTime> raidCreationDate = town.getLastRaidCreationDate();
+        return raidCreationDate.map(dateTime -> Duration.between(dateTime, LocalDateTime.now()).compareTo(config.RAID.RAID_DURATION) >= 0).orElse(true);
     }
 
     public void initRaidTimer() {

--- a/src/main/java/com/atherys/towns/service/TownRaidService.java
+++ b/src/main/java/com/atherys/towns/service/TownRaidService.java
@@ -7,6 +7,9 @@ import com.atherys.towns.model.entity.Town;
 import com.atherys.towns.util.MathUtils;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.spongepowered.api.boss.BossBarColors;
+import org.spongepowered.api.boss.BossBarOverlays;
+import org.spongepowered.api.boss.ServerBossBar;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.scheduler.Task;
@@ -33,6 +36,10 @@ public class TownRaidService {
 
     }
 
+    public double getRaidPercentage(double totalHealth, double currentHealth) {
+        return (currentHealth / totalHealth) * 100;
+    }
+
     public void removeRaidPoint(UUID id) {
         activeRaids.remove(id);
     }
@@ -50,7 +57,14 @@ public class TownRaidService {
     }
 
     public void createRaidPointEntry(Transform<World> transform, Town town, Town targetTown, UUID entityId, Set<UUID> particleEffects) {
-        RaidPoint point = new RaidPoint(LocalDateTime.now(), transform, entityId, town, targetTown, particleEffects);
+        ServerBossBar raidBar = ServerBossBar.builder()
+                .name(Text.of("Hired Mage"))
+                .overlay(BossBarOverlays.PROGRESS)
+                .color(BossBarColors.RED)
+                .percent(1f)
+                .build();
+
+        RaidPoint point = new RaidPoint(LocalDateTime.now(), transform, entityId, town, targetTown, particleEffects, raidBar);
         townService.setTownLastRaidCreationDate(town, LocalDateTime.now());
         activeRaids.put(entityId, point);
     }

--- a/src/main/java/com/atherys/towns/service/TownRaidService.java
+++ b/src/main/java/com/atherys/towns/service/TownRaidService.java
@@ -10,6 +10,7 @@ import com.google.inject.Singleton;
 import org.spongepowered.api.boss.BossBarColors;
 import org.spongepowered.api.boss.BossBarOverlays;
 import org.spongepowered.api.boss.ServerBossBar;
+import org.spongepowered.api.data.key.Keys;
 import org.spongepowered.api.entity.Entity;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.scheduler.Task;
@@ -101,6 +102,19 @@ public class TownRaidService {
     public void removeEntity(World world, UUID uuid) {
         Optional<Entity> entity = world.getEntity(uuid);
         entity.ifPresent(Entity::remove);
+    }
+
+    public double getRaidHealth(World world, RaidPoint point) {
+        Optional<Entity> entity = world.getEntity(point.getRaidPointUUID());
+        if (entity.isPresent()) {
+            return entity.map(value -> Math.round(value.get(Keys.HEALTH).orElse(0.00))).get();
+        }
+        return 0;
+    }
+
+    private void updateBossBar(RaidPoint point) {
+        double raidHealth = getRaidHealth(point.getPointTransform().getExtent(), point);
+        double raidPercentage = getRaidPercentage(config.RAID.RAID_HEALTH, raidHealth);
     }
 
     private Runnable RaidTimerTask() {

--- a/src/main/java/com/atherys/towns/service/TownRaidService.java
+++ b/src/main/java/com/atherys/towns/service/TownRaidService.java
@@ -79,7 +79,7 @@ public class TownRaidService {
     }
 
     public boolean isIdRaidEntity(UUID entityId) {
-        return activeRaids.values().stream().anyMatch(point -> point.getRaidPointUUID().equals(entityId));
+        return activeRaids.containsKey(entityId);
     }
 
     public Optional<RaidPoint> getTownRaidPoint(Town town) {
@@ -104,7 +104,7 @@ public class TownRaidService {
     }
 
     public boolean isLocationTaken(Location<World> location) {
-        double raidDistance = config.RAID.RAID_DISTANCE_BETWEEN_POINTS;
+        double raidDistance = Math.pow(config.RAID.RAID_DISTANCE_BETWEEN_POINTS, 2);
         return activeRaids.values().stream()
                 .anyMatch(point -> MathUtils.getDistanceBetweenPoints(location.getPosition(), point.getPointTransform().getPosition()) < raidDistance);
     }

--- a/src/main/java/com/atherys/towns/service/TownRaidService.java
+++ b/src/main/java/com/atherys/towns/service/TownRaidService.java
@@ -1,0 +1,99 @@
+package com.atherys.towns.service;
+
+import com.atherys.towns.AtherysTowns;
+import com.atherys.towns.TownsConfig;
+import com.atherys.towns.model.RaidPoint;
+import com.atherys.towns.model.entity.Town;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.spongepowered.api.entity.Entity;
+import org.spongepowered.api.entity.Transform;
+import org.spongepowered.api.scheduler.Task;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.world.Location;
+import org.spongepowered.api.world.World;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+@Singleton
+public class TownRaidService {
+    @Inject
+    TownsConfig config;
+
+    @Inject
+    TownService townService;
+
+    Map<UUID, RaidPoint> activeRaids = new HashMap<>();
+
+    public TownRaidService() {
+
+    }
+
+    public void removeRaidPoint(UUID id) {
+        activeRaids.remove(id);
+    }
+
+    public boolean isIdRaidEntity(UUID entityId) {
+        return activeRaids.values().stream().anyMatch(point -> point.getRaidPointUUID().equals(entityId));
+    }
+
+    public Optional<RaidPoint> getTownRaidPoint(Town town) {
+        return activeRaids.values().stream().filter(point -> point.getRaidingTown().equals(town)).findFirst();
+    }
+
+    public void createRaidPointEntry(Transform<World> transform, Town town, UUID entityId) {
+        RaidPoint point = new RaidPoint(LocalDateTime.now(), transform, entityId, town);
+        townService.setTownLastRaidCreationDate(town, LocalDateTime.now());
+        activeRaids.put(entityId, point);
+    }
+
+    public boolean isTownRaidActive(Town town) {
+        return getTownRaidPoint(town).isPresent();
+    }
+
+    public boolean isLocationTaken(Location<World> location) {
+        return activeRaids.values().stream().anyMatch(raidPoint -> raidPoint.getPointTransform().getLocation() == location);
+    }
+
+    public boolean hasCooldownPeriodPassed(Town town) {
+        if (town.getLastRaidCreationDate() != null) {
+            return Duration.between(town.getLastRaidCreationDate(), LocalDateTime.now()).compareTo(config.RAID.RAID_COOLDOWN) >= 0;
+        }
+        return true;
+    }
+
+    public boolean hasDurationPassed(Town town) {
+        if (town.getLastRaidCreationDate() != null) {
+            return Duration.between(town.getLastRaidCreationDate(), LocalDateTime.now()).compareTo(config.RAID.RAID_DURATION) >= 0;
+        }
+        return true;
+    }
+
+    public void initRaidTimer() {
+        Task.Builder taxTimer = Task.builder();
+        taxTimer.interval(2, TimeUnit.SECONDS)
+                .execute(RaidTimerTask())
+                .submit(AtherysTowns.getInstance());
+    }
+
+    private Runnable RaidTimerTask() {
+        return () -> {
+            Set<UUID> pointsToRemove = new HashSet<>();
+            activeRaids.forEach((uuid, point) -> {
+                if (hasDurationPassed(point.getRaidingTown())) {
+                    Optional<Entity> entity = point.getPointTransform().getExtent().getEntity(point.getRaidPointUUID());
+                    entity.ifPresent(Entity::remove);
+                    entity.ifPresent(raidPointEntity -> pointsToRemove.add(raidPointEntity.getUniqueId()));
+                    Text raidRemovedText = Text.of("Your raid point has expired!");
+                    AtherysTowns.getInstance().getTownFacade().getOnlineTownMembers(point.getRaidingTown()).forEach(player -> {
+                        AtherysTowns.getInstance().getTownsMessagingService().info(player, raidRemovedText);
+                    });
+                }
+            });
+            pointsToRemove.forEach(this::removeRaidPoint);
+        };
+    }
+}

--- a/src/main/java/com/atherys/towns/service/TownRaidService.java
+++ b/src/main/java/com/atherys/towns/service/TownRaidService.java
@@ -2,7 +2,9 @@ package com.atherys.towns.service;
 
 import com.atherys.towns.AtherysTowns;
 import com.atherys.towns.TownsConfig;
+import com.atherys.towns.facade.TownFacade;
 import com.atherys.towns.facade.TownRaidFacade;
+import com.atherys.towns.facade.TownsMessagingFacade;
 import com.atherys.towns.model.RaidPoint;
 import com.atherys.towns.model.entity.Town;
 import com.atherys.towns.util.MathUtils;
@@ -34,6 +36,15 @@ public class TownRaidService {
 
     @Inject
     TownService townService;
+
+    @Inject
+    TownRaidFacade townRaidFacade;
+
+    @Inject
+    TownFacade townFacade;
+
+    @Inject
+    TownsMessagingFacade townsMsg;
 
     Map<UUID, RaidPoint> activeRaids = new ConcurrentHashMap<>();
 
@@ -76,7 +87,6 @@ public class TownRaidService {
     }
 
     public void createRaidPointEntry(Transform<World> transform, Town town, Town targetTown, UUID entityId, Set<UUID> particleEffects) {
-        TownRaidFacade townRaidFacade = AtherysTowns.getInstance().getTownRaidFacade();
         ServerBossBar raidBar = ServerBossBar.builder()
                 .name(Text.of("Hired Mage | Time Left: ", townRaidFacade.formatDurationLeft(LocalDateTime.now(), config.RAID.RAID_DURATION)))
                 .overlay(BossBarOverlays.PROGRESS)
@@ -149,7 +159,6 @@ public class TownRaidService {
 
     private void updateBossBar(UUID pointId) {
         //Update BossBar health with current entity health
-        TownRaidFacade townRaidFacade = AtherysTowns.getInstance().getTownRaidFacade();
         RaidPoint point = activeRaids.get(pointId);
         double raidHealth = getRaidHealth(point.getPointTransform().getExtent(), point);
         double raidPercentage = (raidHealth / config.RAID.RAID_HEALTH) * 100;
@@ -167,8 +176,8 @@ public class TownRaidService {
                 updateBossBar(uuid);
                 if (hasDurationPassed(point.getRaidingTown())) {
                     pointsToRemove.add(uuid);
-                    AtherysTowns.getInstance().getTownFacade().getOnlineTownMembers(point.getRaidingTown()).forEach(player -> {
-                        AtherysTowns.getInstance().getTownsMessagingService().info(player, Text.of("Your raid point has expired!"));
+                    townFacade.getOnlineTownMembers(point.getRaidingTown()).forEach(player -> {
+                        townsMsg.info(player, Text.of("Your raid point has expired!"));
                     });
                 }
             });

--- a/src/main/java/com/atherys/towns/service/TownRaidService.java
+++ b/src/main/java/com/atherys/towns/service/TownRaidService.java
@@ -48,8 +48,8 @@ public class TownRaidService {
         return activeRaids.values().stream().filter(point -> point.getRaidingTown().equals(town)).findFirst();
     }
 
-    public void createRaidPointEntry(Transform<World> transform, Town town, UUID entityId, Set<UUID> particleEffects) {
-        RaidPoint point = new RaidPoint(LocalDateTime.now(), transform, entityId, town, particleEffects);
+    public void createRaidPointEntry(Transform<World> transform, Town town, Town targetTown, UUID entityId, Set<UUID> particleEffects) {
+        RaidPoint point = new RaidPoint(LocalDateTime.now(), transform, entityId, town, targetTown, particleEffects);
         townService.setTownLastRaidCreationDate(town, LocalDateTime.now());
         activeRaids.put(entityId, point);
     }

--- a/src/main/java/com/atherys/towns/service/TownService.java
+++ b/src/main/java/com/atherys/towns/service/TownService.java
@@ -12,6 +12,7 @@ import com.atherys.towns.persistence.ResidentRepository;
 import com.atherys.towns.persistence.TownRepository;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import net.bytebuddy.asm.Advice;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.entity.Transform;
 import org.spongepowered.api.entity.living.player.Player;
@@ -97,7 +98,6 @@ public class TownService {
         town.setPvpEnabled(DEFAULT_TOWN_PVP);
         town.setFreelyJoinable(DEFAULT_TOWN_FREELY_JOINABLE);
         town.setWorld(leader.getWorld().getUniqueId());
-        town.setLastRaidCreationDate(LocalDateTime.now());
         town.setBank(UUID.randomUUID());
         town.setNation(nation);
         if (AtherysTowns.economyIsEnabled()) {
@@ -182,6 +182,11 @@ public class TownService {
 
     public void setTownSpawn(Town town, Transform<World> spawn) {
         town.setSpawn(spawn);
+        townRepository.saveOne(town);
+    }
+
+    public void setTownLastRaidCreationDate(Town town, LocalDateTime dateTime) {
+        town.setLastRaidCreationDate(dateTime);
         townRepository.saveOne(town);
     }
 

--- a/src/main/java/com/atherys/towns/service/TownService.java
+++ b/src/main/java/com/atherys/towns/service/TownService.java
@@ -24,6 +24,7 @@ import org.spongepowered.api.text.format.TextColors;
 import org.spongepowered.api.util.Tuple;
 import org.spongepowered.api.world.World;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -96,6 +97,7 @@ public class TownService {
         town.setPvpEnabled(DEFAULT_TOWN_PVP);
         town.setFreelyJoinable(DEFAULT_TOWN_FREELY_JOINABLE);
         town.setWorld(leader.getWorld().getUniqueId());
+        town.setLastRaidCreationDate(LocalDateTime.now());
         town.setBank(UUID.randomUUID());
         town.setNation(nation);
         if (AtherysTowns.economyIsEnabled()) {

--- a/src/main/java/com/atherys/towns/util/MathUtils.java
+++ b/src/main/java/com/atherys/towns/util/MathUtils.java
@@ -4,6 +4,7 @@ import com.atherys.towns.model.entity.Plot;
 import com.flowpowered.math.vector.Vector2i;
 import com.flowpowered.math.vector.Vector3d;
 import com.flowpowered.math.vector.Vector3i;
+import org.spongepowered.api.entity.living.player.Player;
 
 import java.util.*;
 
@@ -96,39 +97,35 @@ public class MathUtils {
         return Collections.min(pointDistances.entrySet(), (entry1, entry2) -> (int) (entry1.getKey() - entry2.getKey())).getValue();
     }
 
+    public static double getDistanceToPlot(Plot plot, Vector2i point) {
+        int plotMinX = plot.getSouthWestCorner().getX();
+        int plotMaxX = plot.getNorthEastCorner().getX();
+        int plotMinY = plot.getSouthWestCorner().getY();
+        int plotMaxY = plot.getNorthEastCorner().getY();
+        int pointX = point.getX();
+        int pointY = point.getY();
+
+        if (pointX < plotMinX) {
+            if (pointY <  plotMinY) return Math.hypot(plotMinX-pointX, plotMinY-pointY);
+            if (pointY <= plotMaxY) return plotMinX - pointX;
+            return Math.hypot(plotMinX-pointX, plotMaxY-pointY);
+        } else if (pointX <= plotMaxX) {
+            if (pointY <  plotMinY) return plotMinY - pointY;
+            if (pointY <= plotMaxY) return 0;
+            return pointY - plotMaxY;
+        } else {
+            if (pointY <  plotMinY) return Math.hypot(plotMaxX-pointX, plotMinY-pointY);
+            if (pointY <= plotMaxY) return pointX - plotMaxX;
+            return Math.hypot(plotMaxX-pointX, plotMaxY-pointY);
+        }
+    }
+
     public static double getSmallestDistanceToTown(Set<Plot> townPlots, Vector2i targetPoint) {
         Vector2i closestPlotPointVector = getClosestPlot(townPlots, targetPoint);
         Plot plot = townPlots.stream().filter(plot1 -> plot1.getSouthWestCorner().equals(closestPlotPointVector)
                 || plot1.getNorthEastCorner().equals(closestPlotPointVector)).findFirst().get();
 
-        Vector2i NECorner = plot.getNorthEastCorner();
-        Vector2i SWCorner = plot.getSouthWestCorner();
-
-        int xLength = getXLength(NECorner, SWCorner);
-        int zLength = getZLength(NECorner, SWCorner);
-
-        Set<Vector2i> plotBorderPoints = new HashSet<>();
-
-        for (int i = 0; i < xLength; i++) {
-            if (NECorner.equals(closestPlotPointVector)) {
-                plotBorderPoints.add(new Vector2i(NECorner.getX() - i, NECorner.getY()));
-            }
-            if (SWCorner.equals(closestPlotPointVector)) {
-                plotBorderPoints.add(new Vector2i(SWCorner.getX() + i, SWCorner.getY()));
-            }
-        }
-        for (int i = 0; i < zLength; i++) {
-            if (NECorner.equals(closestPlotPointVector)) {
-                plotBorderPoints.add(new Vector2i(NECorner.getX(), NECorner.getY() + i));
-            }
-            if (SWCorner.equals(closestPlotPointVector)) {
-                plotBorderPoints.add(new Vector2i(SWCorner.getX(), SWCorner.getY() - i));
-            }
-        }
-
-        Map<Double, Vector2i> pointDistances = new HashMap<>();
-        plotBorderPoints.forEach(plotVector -> pointDistances.put(getDistanceBetweenPoints(targetPoint, plotVector), plotVector));
-        return Collections.min(pointDistances.entrySet(), (entry1, entry2) -> (int) (entry1.getKey() - entry2.getKey())).getKey();
+        return getDistanceToPlot(plot, targetPoint);
     }
 
 

--- a/src/main/java/com/atherys/towns/util/MathUtils.java
+++ b/src/main/java/com/atherys/towns/util/MathUtils.java
@@ -14,7 +14,7 @@ public class MathUtils {
         return Vector2i.from(vector3d.getFloorX(), vector3d.getFloorZ());
     }
 
-    public static double getDistanceBetweenPoints(Vector3d point1, Vector3d point2) {
+    public static double getDistanceBetweenPointsSquared(Vector3d point1, Vector3d point2) {
         return Math.pow(point2.getFloorX() - point1.getFloorX(), 2) + Math.pow(point2.getFloorZ() - point1.getFloorZ(), 2);
     }
 
@@ -74,17 +74,17 @@ public class MathUtils {
         );
     }
 
-    public static double getDistanceToPlot(Vector2i point, Vector2i NECorner, Vector2i SWCorner) {
+    public static double getDistanceToPlotSquared(Vector2i point, Vector2i NECorner, Vector2i SWCorner) {
         int lengthX = MathUtils.getXLength(NECorner, SWCorner);
         int lengthZ = MathUtils.getZLength(NECorner, SWCorner);
 
-        double centerX = (double)(NECorner.getX() + SWCorner.getX()) / 2;
-        double centerZ = (double)(NECorner.getY() + SWCorner.getY()) / 2;
+        double centerX = (double) (NECorner.getX() + SWCorner.getX()) / 2;
+        double centerZ = (double) (NECorner.getY() + SWCorner.getY()) / 2;
 
-        double pointXLength = Math.max(Math.abs(point.getX() - centerX) - (double)lengthX / 2, 0);
-        double pointYLength = Math.max(Math.abs(point.getY() - centerZ) - (double)lengthZ / 2, 0);
+        double pointXLength = Math.max(Math.abs(point.getX() - centerX) - (double) lengthX / 2, 0);
+        double pointYLength = Math.max(Math.abs(point.getY() - centerZ) - (double) lengthZ / 2, 0);
 
-        return pointXLength * pointXLength + pointYLength * pointYLength;
+        return Math.pow(pointXLength, 2) + Math.pow(pointYLength, 2);
     }
 
 

--- a/src/main/java/com/atherys/towns/util/MathUtils.java
+++ b/src/main/java/com/atherys/towns/util/MathUtils.java
@@ -10,6 +10,10 @@ public class MathUtils {
         return Vector2i.from(vector3i.getX(), vector3i.getZ());
     }
 
+    public static double getDistanceBetweenPoints(Vector3d point1, Vector3d point2) {
+        return Math.sqrt(Math.pow(point2.getFloorX() - point1.getFloorX(), 2) + Math.pow(point2.getFloorZ() - point1.getFloorZ(), 2));
+    }
+
     public static int getXLength(Vector2i pointA, Vector2i pointB) {
         return pointA.getX() - pointB.getX();
     }

--- a/src/main/java/com/atherys/towns/util/MathUtils.java
+++ b/src/main/java/com/atherys/towns/util/MathUtils.java
@@ -1,12 +1,8 @@
 package com.atherys.towns.util;
 
-import com.atherys.towns.model.entity.Plot;
 import com.flowpowered.math.vector.Vector2i;
 import com.flowpowered.math.vector.Vector3d;
 import com.flowpowered.math.vector.Vector3i;
-import org.spongepowered.api.entity.living.player.Player;
-
-import java.util.*;
 
 public class MathUtils {
 
@@ -20,10 +16,6 @@ public class MathUtils {
 
     public static double getDistanceBetweenPoints(Vector3d point1, Vector3d point2) {
         return Math.sqrt(Math.pow(point2.getFloorX() - point1.getFloorX(), 2) + Math.pow(point2.getFloorZ() - point1.getFloorZ(), 2));
-    }
-
-    public static double getDistanceBetweenPoints(Vector2i point1, Vector2i point2) {
-        return Math.sqrt(Math.pow(point2.getX() - point1.getX(), 2) + Math.pow(point2.getY() - point1.getY(), 2));
     }
 
     public static int getXLength(Vector2i pointA, Vector2i pointB) {
@@ -82,50 +74,27 @@ public class MathUtils {
         );
     }
 
-    private static Set<Vector2i> getTownPlotPoints(Set<Plot> plots) {
-        Set<Vector2i> plotPoints = new HashSet<>();
-        plots.forEach(plot -> {
-            plotPoints.add(plot.getNorthEastCorner());
-            plotPoints.add(plot.getSouthWestCorner());
-        });
-        return plotPoints;
-    }
-
-    private static Vector2i getClosestPlot(Set<Plot> plots, Vector2i targetPoint) {
-        Map<Double, Vector2i> pointDistances = new HashMap<>();
-        getTownPlotPoints(plots).forEach(plotVector -> pointDistances.put(getDistanceBetweenPoints(targetPoint, plotVector), plotVector));
-        return Collections.min(pointDistances.entrySet(), (entry1, entry2) -> (int) (entry1.getKey() - entry2.getKey())).getValue();
-    }
-
-    public static double getDistanceToPlot(Plot plot, Vector2i point) {
-        int plotMinX = plot.getSouthWestCorner().getX();
-        int plotMaxX = plot.getNorthEastCorner().getX();
-        int plotMinY = plot.getSouthWestCorner().getY();
-        int plotMaxY = plot.getNorthEastCorner().getY();
+    public static double getDistanceToPlot(Vector2i point, Vector2i NECorner, Vector2i SWCorner) {
+        int plotMinX = SWCorner.getX();
+        int plotMaxX = NECorner.getX();
+        int plotMinY = NECorner.getY();
+        int plotMaxY = SWCorner.getY();
         int pointX = point.getX();
         int pointY = point.getY();
 
         if (pointX < plotMinX) {
-            if (pointY <  plotMinY) return Math.hypot(plotMinX-pointX, plotMinY-pointY);
+            if (pointY < plotMinY) return Math.hypot(plotMinX - pointX, plotMinY - pointY);
             if (pointY <= plotMaxY) return plotMinX - pointX;
-            return Math.hypot(plotMinX-pointX, plotMaxY-pointY);
+            return Math.hypot(plotMinX - pointX, plotMaxY - pointY);
         } else if (pointX <= plotMaxX) {
-            if (pointY <  plotMinY) return plotMinY - pointY;
+            if (pointY < plotMinY) return plotMinY - pointY;
             if (pointY <= plotMaxY) return 0;
             return pointY - plotMaxY;
         } else {
-            if (pointY <  plotMinY) return Math.hypot(plotMaxX-pointX, plotMinY-pointY);
+            if (pointY < plotMinY) return Math.hypot(plotMaxX - pointX, plotMinY - pointY);
             if (pointY <= plotMaxY) return pointX - plotMaxX;
-            return Math.hypot(plotMaxX-pointX, plotMaxY-pointY);
+            return Math.hypot(plotMaxX - pointX, plotMaxY - pointY);
         }
-    }
-
-    public static double getSmallestDistanceToTown(Set<Plot> townPlots, Vector2i targetPoint) {
-        Vector2i closestPlotPointVector = getClosestPlot(townPlots, targetPoint);
-        Plot plot = townPlots.stream().filter(plot1 -> plot1.getSouthWestCorner().equals(closestPlotPointVector)
-                || plot1.getNorthEastCorner().equals(closestPlotPointVector)).findFirst().get();
-
-        return getDistanceToPlot(plot, targetPoint);
     }
 
 

--- a/src/main/java/com/atherys/towns/util/MathUtils.java
+++ b/src/main/java/com/atherys/towns/util/MathUtils.java
@@ -15,7 +15,7 @@ public class MathUtils {
     }
 
     public static double getDistanceBetweenPoints(Vector3d point1, Vector3d point2) {
-        return Math.sqrt(Math.pow(point2.getFloorX() - point1.getFloorX(), 2) + Math.pow(point2.getFloorZ() - point1.getFloorZ(), 2));
+        return Math.pow(point2.getFloorX() - point1.getFloorX(), 2) + Math.pow(point2.getFloorZ() - point1.getFloorZ(), 2);
     }
 
     public static int getXLength(Vector2i pointA, Vector2i pointB) {
@@ -75,26 +75,16 @@ public class MathUtils {
     }
 
     public static double getDistanceToPlot(Vector2i point, Vector2i NECorner, Vector2i SWCorner) {
-        int plotMinX = SWCorner.getX();
-        int plotMaxX = NECorner.getX();
-        int plotMinY = NECorner.getY();
-        int plotMaxY = SWCorner.getY();
-        int pointX = point.getX();
-        int pointY = point.getY();
+        int lengthX = MathUtils.getXLength(NECorner, SWCorner);
+        int lengthZ = MathUtils.getZLength(NECorner, SWCorner);
 
-        if (pointX < plotMinX) {
-            if (pointY < plotMinY) return Math.hypot(plotMinX - pointX, plotMinY - pointY);
-            if (pointY <= plotMaxY) return plotMinX - pointX;
-            return Math.hypot(plotMinX - pointX, plotMaxY - pointY);
-        } else if (pointX <= plotMaxX) {
-            if (pointY < plotMinY) return plotMinY - pointY;
-            if (pointY <= plotMaxY) return 0;
-            return pointY - plotMaxY;
-        } else {
-            if (pointY < plotMinY) return Math.hypot(plotMaxX - pointX, plotMinY - pointY);
-            if (pointY <= plotMaxY) return pointX - plotMaxX;
-            return Math.hypot(plotMaxX - pointX, plotMaxY - pointY);
-        }
+        double centerX = (double)(NECorner.getX() + SWCorner.getX()) / 2;
+        double centerZ = (double)(NECorner.getY() + SWCorner.getY()) / 2;
+
+        double pointXLength = Math.max(Math.abs(point.getX() - centerX) - (double)lengthX / 2, 0);
+        double pointYLength = Math.max(Math.abs(point.getY() - centerZ) - (double)lengthZ / 2, 0);
+
+        return pointXLength * pointXLength + pointYLength * pointYLength;
     }
 
 


### PR DESCRIPTION
This PR implements #73 with all requirements outlined in the Town document met.

Changes included not in the document:
1. Raid spawn point makes a little more sense RP wise, now has a hired mage teleport you back, and you need to defeat him to stop enemy players from raiding you.
2. added options to prevent abuse such as a MAX and MIN raid spawn point distance to the target town.
3. It currently only checks if the town is enemies via their nation as town specific enemies are not implemented yet.

Commands:
/town raid create
/town raid info
/town raid cancel